### PR TITLE
ci: Update to add setting new toolchain env var

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -9,6 +9,7 @@ env:
         - SANITYCHECK_OPTIONS_RETRY=" --only-failed --outdir=out-2nd-pass"
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.2
         - ZEPHYR_GCC_VARIANT=zephyr
+        - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - USE_CCACHE=1
         - COVERAGE="--all --enable-slow"
         - QEMU_BIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/


### PR DESCRIPTION
Added ZEPHYR_TOOLCHAIN_VARIANT to match upstream zephyr, keep
ZEPHYR_GCC_VARIANT so if we are building older releases things still
work.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>