### PR TITLE
ci: Update issm and gccarmemb to use ZEPHYR_TOOLCHAIN_VARIANT

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -14,7 +14,7 @@ env:
         - QEMU_BIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/
         - QEMU_BIOS=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/share/qemu
         - DTC=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/dtc
-        - MATRIX_BUILDS="12"
+        - MATRIX_BUILDS="15"
     matrix:
         - MATRIX_BUILD="1"
         - MATRIX_BUILD="2"
@@ -28,6 +28,9 @@ env:
         - MATRIX_BUILD="10"
         - MATRIX_BUILD="11"
         - MATRIX_BUILD="12"
+        - MATRIX_BUILD="13"
+        - MATRIX_BUILD="14"
+        - MATRIX_BUILD="15"
 
 build:
     cache: true


### PR DESCRIPTION
We changed the env var from ZEPHYR_GCC_VARIANT to
ZEPHYR_TOOLCHAIN_VARIANT.  So update usage for when we build with issm
or gccarmemb

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>