### PR TITLE
ci: Remove setting QEMU path

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -37,7 +37,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.6.1
+        image_tag: v0.6.2
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
For right now don't explicitly set the QEMU path, this should allow us
to find the x86_64 qemu from the system.  As the SDK doesn't have a
x86_64 qemu in it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>