### PR TITLE
ci: export QEMU variables after sourcing environment

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -7,12 +7,7 @@ env:
         - SDK=0.9.5
         - SANITYCHECK_OPTIONS=" --inline-logs -N"
         - SANITYCHECK_OPTIONS_RETRY=" --only-failed --outdir=out-2nd-pass"
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.5
-        - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         - COVERAGE="--all "
-        - QEMU_BIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/
-        - QEMU_BIOS=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/share/qemu
-        - DTC=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/dtc
         - MATRIX_BUILDS="20"
     matrix:
         - MATRIX_BUILD="1"
@@ -52,6 +47,9 @@ build:
       - cp $CI_TEST_PREP_STATE/tests.csv.gz .
       - cp $CI_TEST_PREP_STATE/zephyrrc .
       - source zephyrrc
+      - export QEMU_BIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/
+      - export QEMU_BIOS=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/share/qemu
+      - export DTC=${ZEPHYR_SDK_INSTALL_DIR}/sysroots/x86_64-pokysdk-linux/usr/bin/dtc
       - cat zephyrrc
       - gzip -d tests.csv.gz
       - source zephyr-env.sh


### PR DESCRIPTION
We get the SDK variant from the pipeline, so export QEMU env variables
after sourcing.