### PR TITLE
ci: Add 'west update' to get modules "installed"

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -43,6 +43,7 @@ build:
     ci:
       - git submodule update --remote
       - cd zephyr
+      - west update
       - cp $CI_TEST_PREP_STATE/tests.csv.gz .
       - cp $CI_TEST_PREP_STATE/zephyrrc .
       - source zephyrrc


### PR DESCRIPTION
We need to invoke 'west update' to get modules cloned/etc so any builds
that require them have the code available.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>