### PR TITLE
ci: Change nightly build to build-only

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -4,7 +4,7 @@ compiler: gcc
 
 env:
     global:
-        - SANITYCHECK_OPTIONS=" --inline-logs -N"
+        - SANITYCHECK_OPTIONS=" --inline-logs -N --build-only"
         - SANITYCHECK_OPTIONS_RETRY=" --only-failed --outdir=out-2nd-pass"
         - COVERAGE="--all "
         - MATRIX_BUILDS="20"


### PR DESCRIPTION
Change nightly so we only do builds and not also runs.  We will seperate
out doing runs of QEMU and publishing of results as a seperate
activiity.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>