### PR TITLE
ci: always email build results

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -96,5 +96,5 @@ integrations:
       branches:
         only:
           - master
-      on_success: never
+      on_success: always
       on_failure: always


### PR DESCRIPTION
Regardless of success or failure we should always report build results
to email.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>