### PR TITLE
ci: Update sdk to 0.11.3

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -7,7 +7,7 @@ env:
         - SANITYCHECK_OPTIONS=" --inline-logs -N --build-only --all --retry-failed 3 -v "
         - MATRIX_BUILDS="35"
         - ZEPHYR_TOOLCHAIN_VARIANT="zephyr"
-        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.2
+        - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.11.3
     matrix:
         - MATRIX_BUILD="1"
         - MATRIX_BUILD="2"
@@ -51,7 +51,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: v0.11.6
+        image_tag: v0.11.8
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 


### PR DESCRIPTION
Update sdk to 0.11.3 release and update docker image to get that SDK
version.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>